### PR TITLE
Update portfolio color palette

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,9 +14,9 @@
   --bs-blue: #0d6efd;
   --bs-indigo: #6610f2;
   --bs-purple: #6f42c1;
-  --bs-pink: #ee0979;
+  --bs-pink: #1f3c88;
   --bs-red: #dc3545;
-  --bs-orange: #ff6a00;
+  --bs-orange: #0f3460;
   --bs-yellow: #ffc107;
   --bs-green: #198754;
   --bs-teal: #20c997;
@@ -34,16 +34,16 @@
   --bs-gray-700: #495057;
   --bs-gray-800: #343a40;
   --bs-gray-900: #212529;
-  --bs-primary: #ee0979;
-  --bs-secondary: #ff6a00;
+  --bs-primary: #1f3c88;
+  --bs-secondary: #0f3460;
   --bs-success: #198754;
   --bs-info: #0dcaf0;
   --bs-warning: #ffc107;
   --bs-danger: #dc3545;
   --bs-light: #f8f9fa;
   --bs-dark: #212529;
-  --bs-primary-rgb: 238, 9, 121;
-  --bs-secondary-rgb: 255, 106, 0;
+  --bs-primary-rgb: 31, 60, 136;
+  --bs-secondary-rgb: 15, 52, 96;
   --bs-success-rgb: 25, 135, 84;
   --bs-info-rgb: 13, 202, 240;
   --bs-warning-rgb: 255, 193, 7;
@@ -73,9 +73,9 @@
   --bs-border-radius-xl: 1rem;
   --bs-border-radius-2xl: 2rem;
   --bs-border-radius-pill: 50rem;
-  --bs-link-color: #ee0979;
-  --bs-link-hover-color: #be0761;
-  --bs-code-color: #ee0979;
+  --bs-link-color: #1f3c88;
+  --bs-link-hover-color: #162860;
+  --bs-code-color: #1f3c88;
   --bs-highlight-bg: #fff3cd;
 }
 
@@ -2022,9 +2022,9 @@ progress {
 .form-control:focus {
   color: #212529;
   background-color: #fff;
-  border-color: #f784bc;
+  border-color: #3d66b5;
   outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
 }
 .form-control::-webkit-date-and-time-value {
   height: 1.5em;
@@ -2169,9 +2169,9 @@ textarea.form-control-lg {
   }
 }
 .form-select:focus {
-  border-color: #f784bc;
+  border-color: #3d66b5;
   outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
 }
 .form-select[multiple], .form-select[size]:not([size="1"]) {
   padding-right: 0.75rem;
@@ -2249,13 +2249,13 @@ textarea.form-control-lg {
   filter: brightness(90%);
 }
 .form-check-input:focus {
-  border-color: #f784bc;
+  border-color: #3d66b5;
   outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
 }
 .form-check-input:checked {
-  background-color: #ee0979;
-  border-color: #ee0979;
+  background-color: #1f3c88;
+  border-color: #1f3c88;
 }
 .form-check-input:checked[type=checkbox] {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
@@ -2264,8 +2264,8 @@ textarea.form-control-lg {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='%23fff'/%3e%3c/svg%3e");
 }
 .form-check-input[type=checkbox]:indeterminate {
-  background-color: #ee0979;
-  border-color: #ee0979;
+  background-color: #1f3c88;
+  border-color: #1f3c88;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e");
 }
 .form-check-input:disabled {
@@ -2295,7 +2295,7 @@ textarea.form-control-lg {
   }
 }
 .form-switch .form-check-input:focus {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23f784bc'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%233d66b5'/%3e%3c/svg%3e");
 }
 .form-switch .form-check-input:checked {
   background-position: right center;
@@ -2339,10 +2339,10 @@ textarea.form-control-lg {
   outline: 0;
 }
 .form-range:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
 }
 .form-range:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
 }
 .form-range::-moz-focus-outer {
   border: 0;
@@ -2351,7 +2351,7 @@ textarea.form-control-lg {
   width: 1rem;
   height: 1rem;
   margin-top: -0.25rem;
-  background-color: #ee0979;
+  background-color: #1f3c88;
   border: 0;
   border-radius: 1rem;
   -webkit-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
@@ -2380,7 +2380,7 @@ textarea.form-control-lg {
 .form-range::-moz-range-thumb {
   width: 1rem;
   height: 1rem;
-  background-color: #ee0979;
+  background-color: #1f3c88;
   border: 0;
   border-radius: 1rem;
   -moz-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
@@ -2846,36 +2846,36 @@ textarea.form-control-lg {
 
 .btn-primary {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #ee0979;
-  --bs-btn-border-color: #ee0979;
+  --bs-btn-bg: #1f3c88;
+  --bs-btn-border-color: #1f3c88;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #ca0867;
-  --bs-btn-hover-border-color: #be0761;
-  --bs-btn-focus-shadow-rgb: 241, 46, 141;
+  --bs-btn-hover-bg: #162860;
+  --bs-btn-hover-border-color: #162860;
+  --bs-btn-focus-shadow-rgb: 31, 60, 136;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #be0761;
-  --bs-btn-active-border-color: #b3075b;
+  --bs-btn-active-bg: #13224f;
+  --bs-btn-active-border-color: #13224f;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #ee0979;
-  --bs-btn-disabled-border-color: #ee0979;
+  --bs-btn-disabled-bg: #1f3c88;
+  --bs-btn-disabled-border-color: #1f3c88;
 }
 
 .btn-secondary {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #ff6a00;
-  --bs-btn-border-color: #ff6a00;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #ff8026;
-  --bs-btn-hover-border-color: #ff791a;
-  --bs-btn-focus-shadow-rgb: 217, 90, 0;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #ff8833;
-  --bs-btn-active-border-color: #ff791a;
+  --bs-btn-color: #fff;
+  --bs-btn-bg: #0f3460;
+  --bs-btn-border-color: #0f3460;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #0a253f;
+  --bs-btn-hover-border-color: #0a253f;
+  --bs-btn-focus-shadow-rgb: 15, 52, 96;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #071c30;
+  --bs-btn-active-border-color: #071c30;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #ff6a00;
-  --bs-btn-disabled-border-color: #ff6a00;
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: #0f3460;
+  --bs-btn-disabled-border-color: #0f3460;
 }
 
 .btn-success {
@@ -2981,36 +2981,36 @@ textarea.form-control-lg {
 }
 
 .btn-outline-primary {
-  --bs-btn-color: #ee0979;
-  --bs-btn-border-color: #ee0979;
+  --bs-btn-color: #1f3c88;
+  --bs-btn-border-color: #1f3c88;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #ee0979;
-  --bs-btn-hover-border-color: #ee0979;
-  --bs-btn-focus-shadow-rgb: 238, 9, 121;
+  --bs-btn-hover-bg: #1f3c88;
+  --bs-btn-hover-border-color: #1f3c88;
+  --bs-btn-focus-shadow-rgb: 31, 60, 136;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #ee0979;
-  --bs-btn-active-border-color: #ee0979;
+  --bs-btn-active-bg: #1f3c88;
+  --bs-btn-active-border-color: #1f3c88;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #ee0979;
+  --bs-btn-disabled-color: #1f3c88;
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #ee0979;
+  --bs-btn-disabled-border-color: #1f3c88;
   --bs-gradient: none;
 }
 
 .btn-outline-secondary {
-  --bs-btn-color: #ff6a00;
-  --bs-btn-border-color: #ff6a00;
+  --bs-btn-color: #0f3460;
+  --bs-btn-border-color: #0f3460;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #ff6a00;
-  --bs-btn-hover-border-color: #ff6a00;
-  --bs-btn-focus-shadow-rgb: 255, 106, 0;
+  --bs-btn-hover-bg: #0f3460;
+  --bs-btn-hover-border-color: #0f3460;
+  --bs-btn-focus-shadow-rgb: 15, 52, 96;
   --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #ff6a00;
-  --bs-btn-active-border-color: #ff6a00;
+  --bs-btn-active-bg: #0f3460;
+  --bs-btn-active-border-color: #0f3460;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #ff6a00;
+  --bs-btn-disabled-color: #0f3460;
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #ff6a00;
+  --bs-btn-disabled-border-color: #0f3460;
   --bs-gradient: none;
 }
 
@@ -3128,7 +3128,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #6c757d;
   --bs-btn-disabled-border-color: transparent;
   --bs-btn-box-shadow: none;
-  --bs-btn-focus-shadow-rgb: 241, 46, 141;
+  --bs-btn-focus-shadow-rgb: 31, 60, 136;
   text-decoration: underline;
 }
 .btn-link:focus-visible {
@@ -3235,7 +3235,7 @@ textarea.form-control-lg {
   --bs-dropdown-link-hover-color: #1e2125;
   --bs-dropdown-link-hover-bg: #e9ecef;
   --bs-dropdown-link-active-color: #fff;
-  --bs-dropdown-link-active-bg: #ee0979;
+  --bs-dropdown-link-active-bg: #1f3c88;
   --bs-dropdown-link-disabled-color: #adb5bd;
   --bs-dropdown-item-padding-x: 1rem;
   --bs-dropdown-item-padding-y: 0.25rem;
@@ -3500,7 +3500,7 @@ textarea.form-control-lg {
   --bs-dropdown-divider-bg: var(--bs-border-color-translucent);
   --bs-dropdown-link-hover-bg: rgba(255, 255, 255, 0.15);
   --bs-dropdown-link-active-color: #fff;
-  --bs-dropdown-link-active-bg: #ee0979;
+  --bs-dropdown-link-active-bg: #1f3c88;
   --bs-dropdown-link-disabled-color: #adb5bd;
   --bs-dropdown-header-color: #adb5bd;
 }
@@ -3683,7 +3683,7 @@ textarea.form-control-lg {
 .nav-pills {
   --bs-nav-pills-border-radius: 0.375rem;
   --bs-nav-pills-link-active-color: #fff;
-  --bs-nav-pills-link-active-bg: #ee0979;
+  --bs-nav-pills-link-active-bg: #1f3c88;
 }
 .nav-pills .nav-link {
   background: none;
@@ -4348,8 +4348,8 @@ textarea.form-control-lg {
   --bs-accordion-btn-icon-transform: rotate(-180deg);
   --bs-accordion-btn-icon-transition: transform 0.2s ease-in-out;
   --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23d6086d'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-focus-border-color: #f784bc;
-  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  --bs-accordion-btn-focus-border-color: #3d66b5;
+  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
   --bs-accordion-body-padding-x: 1.25rem;
   --bs-accordion-body-padding-y: 1rem;
   --bs-accordion-active-color: #d6086d;
@@ -4512,10 +4512,10 @@ textarea.form-control-lg {
   --bs-pagination-hover-border-color: #dee2e6;
   --bs-pagination-focus-color: var(--bs-link-hover-color);
   --bs-pagination-focus-bg: #e9ecef;
-  --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
   --bs-pagination-active-color: #fff;
-  --bs-pagination-active-bg: #ee0979;
-  --bs-pagination-active-border-color: #ee0979;
+  --bs-pagination-active-bg: #1f3c88;
+  --bs-pagination-active-border-color: #1f3c88;
   --bs-pagination-disabled-color: #6c757d;
   --bs-pagination-disabled-bg: #fff;
   --bs-pagination-disabled-border-color: #dee2e6;
@@ -4740,7 +4740,7 @@ textarea.form-control-lg {
   --bs-progress-border-radius: 0.375rem;
   --bs-progress-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075);
   --bs-progress-bar-color: #fff;
-  --bs-progress-bar-bg: #ee0979;
+  --bs-progress-bar-bg: #1f3c88;
   --bs-progress-bar-transition: width 0.6s ease;
   display: flex;
   height: var(--bs-progress-height);
@@ -4797,8 +4797,8 @@ textarea.form-control-lg {
   --bs-list-group-disabled-color: #6c757d;
   --bs-list-group-disabled-bg: #fff;
   --bs-list-group-active-color: #fff;
-  --bs-list-group-active-bg: #ee0979;
-  --bs-list-group-active-border-color: #ee0979;
+  --bs-list-group-active-bg: #1f3c88;
+  --bs-list-group-active-border-color: #1f3c88;
   display: flex;
   flex-direction: column;
   padding-left: 0;
@@ -5150,7 +5150,7 @@ textarea.form-control-lg {
 }
 .btn-close:focus {
   outline: 0;
-  box-shadow: 0 0 0 0.25rem rgba(238, 9, 121, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(31, 60, 136, 0.25);
   opacity: 1;
 }
 .btn-close:disabled, .btn-close.disabled {
@@ -6657,12 +6657,12 @@ textarea.form-control-lg {
 
 .text-bg-primary {
   color: #fff !important;
-  background-color: RGBA(238, 9, 121, var(--bs-bg-opacity, 1)) !important;
+  background-color: RGBA(31, 60, 136, var(--bs-bg-opacity, 1)) !important;
 }
 
 .text-bg-secondary {
   color: #000 !important;
-  background-color: RGBA(255, 106, 0, var(--bs-bg-opacity, 1)) !important;
+  background-color: RGBA(15, 52, 96, var(--bs-bg-opacity, 1)) !important;
 }
 
 .text-bg-success {
@@ -6696,17 +6696,17 @@ textarea.form-control-lg {
 }
 
 .link-primary {
-  color: #ee0979 !important;
+  color: #1f3c88 !important;
 }
 .link-primary:hover, .link-primary:focus {
-  color: #be0761 !important;
+  color: #162860 !important;
 }
 
 .link-secondary {
-  color: #ff6a00 !important;
+  color: #0f3460 !important;
 }
 .link-secondary:hover, .link-secondary:focus {
-  color: #ff8833 !important;
+  color: #071c30 !important;
 }
 
 .link-success {
@@ -10860,7 +10860,7 @@ header.masthead {
   overflow: hidden;
   padding-top: calc(7rem + 72px);
   padding-bottom: 7rem;
-  background: linear-gradient(0deg, #ff6a00 0%, #ee0979 100%);
+  background: linear-gradient(0deg, #0f3460 0%, #1f3c88 100%);
   background-repeat: no-repeat;
   background-position: center center;
   background-attachment: scroll;
@@ -10880,7 +10880,7 @@ header.masthead .bg-circle {
   z-index: 0;
   position: absolute;
   border-radius: 100%;
-  background: linear-gradient(0deg, #ee0979 0%, #ff6a00 100%);
+  background: linear-gradient(0deg, #1f3c88 0%, #0f3460 100%);
 }
 header.masthead .bg-circle-1 {
   height: 90rem;


### PR DESCRIPTION
## Summary
- replace the pink and orange accents with a navy-inspired palette via the shared CSS variables
- update button, link, and focus styles to stay consistent with the new colors
- refresh the hero gradient and decorative circles to use the updated tones

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3a46ebfac832a8d8f1c4e9ac39ee5